### PR TITLE
postgresql用の修正

### DIFF
--- a/lib/Qudo/Test.pm
+++ b/lib/Qudo/Test.pm
@@ -311,8 +311,8 @@ Pg:
         message         BYTEA,
         uniqkey         VARCHAR(255) NULL,
         arg             BYTEA,
-        retried         SMALLINT
-        PRIMARY KEY (id),
+        retried         SMALLINT,
+        PRIMARY KEY (id)
     );
   - |-
     CREATE INDEX exception_log_func_id ON exception_log (func_id);
@@ -326,6 +326,6 @@ Pg:
         uniqkey         VARCHAR(255) NULL,
         status          VARCHAR(10),
         job_start_time  INTEGER NOT NULL,
-        job_end_time    INTEGER NOT NULL
-        PRIMARY KEY (id),
+        job_end_time    INTEGER NOT NULL,
+        PRIMARY KEY (id)
     );


### PR DESCRIPTION
Qudo::Testのpostgresql用スキーマを修正してみました。変更点は

・先ほどコメントしたキーの部分
・serialからbigserialへ
・postgresではserial型を指定してもprimary keyにならないので明示的に指定

になります。
