### PR TITLE
Notify die when job failed

### DIFF
--- a/lib/Qudo/Manual/JA/Tutorial.pod
+++ b/lib/Qudo/Manual/JA/Tutorial.pod
@@ -83,6 +83,10 @@ queueingされたJobを処理していくworkerを作成します
         
         # send mail process...
         
+        if ($cannot_send_mail) {
+            die "cannot send mail: reason"; # the message is logged to exception_log
+        }
+
         $job->completed; # finished job!
     }
     1;

--- a/lib/Qudo/Worker.pm
+++ b/lib/Qudo/Worker.pm
@@ -59,7 +59,7 @@ Qudo::Worker - superclass for defining task behavior of Qudo's work
         my $job_arg = $job->arg();
         print "This is Myworker's work. job has argument == $job_arg \n";
 
-        $job->completed(); # or $job->abort
+        $job->completed(); # or die or $job->abort
     }
     1;
 


### PR DESCRIPTION
wokerでdieせずに、failed呼んでしまって、ログが2回(自分のfailedのメッセージと、Qudo::Workerの"Job did not explicitly complete or fail")書き込まれてしまうのが、なんでだろう...と悩んでたので。想定通りの挙動なのかちょっとわからないですが。