### PR TITLE
Dynamic retry_delay setting

### DIFF
--- a/lib/Qudo/Worker.pm
+++ b/lib/Qudo/Worker.pm
@@ -30,7 +30,7 @@ sub work_safely {
                 {
                     grabbed_until => 0,
                     retry_cnt     => $job->retry_cnt + 1,
-                    retry_delay   => $class->retry_delay,
+                    retry_delay   => $class->retry_delay($job),
                 }
             );
         } else {

--- a/t/004worker/retry_delay.t
+++ b/t/004worker/retry_delay.t
@@ -10,7 +10,7 @@ run_tests(3, sub {
 
     my $manager = $master->manager;
     $manager->can_do('Worker::Test');
-    $manager->enqueue("Worker::Test", { arg => 'arg', uniqkey => 'uniqkey'});
+    $manager->enqueue("Worker::Test", { arg => 5, uniqkey => 'uniqkey'});
 
     stdout_is( sub {$manager->work_once}, 0 ); # fail job
 
@@ -27,7 +27,7 @@ package Worker::Test;
 use base 'Qudo::Worker';
 
 sub max_retries { 1 }
-sub retry_delay { 5 } # 5 sec retry wait.
+sub retry_delay { $_[1]->arg }
 sub grab_for    { 0 }
 sub work {
     my ($class, $job) = @_;


### PR DESCRIPTION
Pass `retry_delay` method to job object to configure retry_delay setting dynamically.

eg: like TCP SYN retry

```perl
sub retry_delay { 2 ** $_[1]->retry_cnt }
```