### PR TITLE
Fix job dequeue order with explicit ORDER BY

### DIFF
--- a/lib/Qudo/Driver/Skinny.pm
+++ b/lib/Qudo/Driver/Skinny.pm
@@ -52,7 +52,8 @@ sub _search_job_rs {
             limit  => $args{limit},
         }
     );
-    $rs->order({column => 'job.priority', desc => 'DESC'});
+    $rs->order([{column => 'job.priority', desc => 'DESC'},
+                {column => 'job.id', desc => 'ASC'}]);
 
     return $rs;
 }


### PR DESCRIPTION
Current dequeue query does not use ORDER BY to guarantee the order of
jobs dequeued by workers. But SQL standards does not specify any
behavior of record order without ORDER BY and it depends on
implementations of RDBMS.
So jobs can be dequeued in descending order of enqueue_time, that means
jobs are treated in Stack(FILO) order rather than Queue.

----

As for my environment, MySQL 5.6 uses `priority` index(can be varied by optimizer depends on INNODB statistics), then jobs are dequeued in FILO order. You can reproduce this behavior by adding `FORCE INDEX (priority) ` to dequeue query. 

ex: 

```
> explain select   job.id,   job.arg,   job.uniqkey,   job.func_id,   job.grabbed_until,   job.retry_cnt,   job.priority from   job  where   job.func_id = 10 and job.grabbed_until <= unix_timestamp() and job.run_after <= unix_timestamp() order by   job.priority DESC;
+----+-------------+-------+-------+---------------+----------+---------+------+------+-------------+
| id | select_type | table | type  | possible_keys | key      | key_len | ref  | rows | Extra       |
+----+-------------+-------+-------+---------------+----------+---------+------+------+-------------+
|  1 | SIMPLE      | job   | index | NULL          | priority | 4       | NULL |    5 | Using where |
+----+-------------+-------+-------+---------------+----------+---------+------+------+-------------+

> select   job.id,   job.arg,   job.uniqkey,   job.func_id,   job.grabbed_until,   job.retry_cnt,   job.priority from   job  where   job.func_id = 10 and job.grabbed_until <= unix_timestamp() and job.run_after <= unix_timestamp() order by   job.priority DESC;
+---------+------+---------+---------+---------------+-----------+----------+
| id      | arg  | uniqkey | func_id | grabbed_until | retry_cnt | priority |
+---------+------+---------+---------+---------------+-----------+----------+
| 1771333 | NULL | c       |      10 |             0 |         0 |        5 |
| 1771332 | NULL | b       |      10 |             0 |         0 |        5 |
| 1771331 | NULL | a       |      10 |             0 |         0 |        5 |
+---------+------+---------+---------+---------------+-----------+----------+
```

